### PR TITLE
Require clean Git

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     testCompile("com.atlassian.performance.tools:aws-resources:[1.3.4,2.0.0)")
     testCompile("com.atlassian.performance.tools:concurrency:[1.0.0,2.0.0)")
     testCompile("org.apache.commons:commons-csv:1.4")
+    testCompile("org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r")
     testCompile("junit:junit:4.12")
     testCompile("org.hamcrest:hamcrest-library:1.3")
     testCompile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70")

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -34,7 +34,9 @@ com.google.code.gson:gson:2.8.2
 com.google.errorprone:error_prone_annotations:2.1.3
 com.google.guava:guava:23.6-jre
 com.google.j2objc:j2objc-annotations:1.1
+com.googlecode.javaewah:JavaEWAH:1.1.6
 com.hierynomus:sshj:0.23.0
+com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.3
 com.squareup.okhttp3:okhttp:3.9.1
 com.squareup.okio:okio:1.13.0
@@ -60,6 +62,7 @@ org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.checkerframework:checker-compat-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
+org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
 org.glassfish.jaxb:jaxb-core:2.3.0
 org.glassfish.jaxb:jaxb-runtime:2.3.0
 org.glassfish.jaxb:txw2:2.3.0

--- a/src/test/kotlin/com/atlassian/performance/tools/lib/workspace/GitRepo.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/lib/workspace/GitRepo.kt
@@ -1,0 +1,24 @@
+package com.atlassian.performance.tools.lib.workspace
+
+import org.eclipse.jgit.internal.storage.file.FileRepository
+import org.eclipse.jgit.lib.Repository
+import java.io.File
+
+object GitRepo2 {
+
+    fun findInAncestors(
+        descendant: File
+    ): Repository? {
+        if (descendant.isDirectory) {
+            descendant
+                .listFiles()
+                .singleOrNull { it.name == ".git" }
+                ?.let { return FileRepository(it) }
+        }
+        val parent = descendant.parentFile
+        return when (parent) {
+            null -> null
+            else -> findInAncestors(parent)
+        }
+    }
+}


### PR DESCRIPTION
For example, we get zipped DB exploration results, the charts point to https://github.com/atlassian/jira-hardware-exploration/commit/bacba7ff9354cfb661eb951a19736306e67a948d
This commit has no DB exploration code at all. It's impossible to resume someone else's work this way.