### PR TITLE
Issue/quick 115 fix s3 upload of existing files

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/hardware/HardwareExploration.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/hardware/HardwareExploration.kt
@@ -60,6 +60,9 @@ class HardwareExploration(
 
     fun exploreHardware(): List<HardwareExplorationResult> {
         val space = guidance.space()
+        if (space.isEmpty()) {
+            return emptyList()
+        }
         val awsExecutor = Executors.newFixedThreadPool(awsParallelism)
         val explorationExecutor = Executors.newFixedThreadPool(space.size)
         try {

--- a/src/test/kotlin/com/atlassian/performance/tools/lib/s3cache/EtagCache.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/lib/s3cache/EtagCache.kt
@@ -1,7 +1,7 @@
 package com.atlassian.performance.tools.lib.s3cache
 
 import com.amazonaws.services.s3.transfer.Download
-import com.amazonaws.services.s3.transfer.Upload
+import com.amazonaws.services.s3.transfer.model.UploadResult
 import com.atlassian.performance.tools.io.api.ensureParentDirectory
 import com.atlassian.performance.tools.lib.toExistingFile
 import net.jcip.annotations.NotThreadSafe
@@ -24,7 +24,6 @@ class EtagCache(
     fun write(
         download: Download
     ) {
-        download.waitForCompletion()
         locate(download.key)
             .toFile()
             .ensureParentDirectory()
@@ -32,13 +31,12 @@ class EtagCache(
     }
 
     fun write(
-        upload: Upload
+        upload: UploadResult
     ) {
-        val uploadResult = upload.waitForUploadResult()
-        locate(uploadResult.key)
+        locate(upload.key)
             .toFile()
             .ensureParentDirectory()
-            .writeText(uploadResult.eTag)
+            .writeText(upload.eTag)
 
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/lib/s3cache/S3Cache.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/lib/s3cache/S3Cache.kt
@@ -130,12 +130,8 @@ class S3Cache(
     ): Boolean {
         val localKey = s3Prefix + local.relativeTo(localDirectory).path // TODO might not work on Windows
         val s3Object = s3Objects.find { it.key == localKey } ?: return true
-        val localEtag = etags.read(localKey)
-        if (s3Object.eTag == localEtag) {
-            return false
-        }
-        val s3Freshness = s3Object.lastModified.toInstant()
-        val localFreshness = Instant.ofEpochMilli(local.lastModified())
+        val localFreshness = local.lastModified()
+        val s3Freshness = s3Object.lastModified.time
         return localFreshness > s3Freshness
     }
 


### PR DESCRIPTION
Now the generated charts are uploaded even if they were previously cached.

It worked: https://server-gdn-bamboo.internal.atlassian.com/browse/QUICK-JHWR11-1