### PR TITLE
[RFC] Change avoidCompressedOopsPenalty to actualy avoid compressed oops penalty

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/hardware/tuning/HeapTuning.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/hardware/tuning/HeapTuning.kt
@@ -65,7 +65,7 @@ class HeapTuning : JiraNodeTuning {
         desiredGigabytes: Int
     ): Int {
         return if (desiredGigabytes in (32..40)) {
-            32
+            31
         } else {
             desiredGigabytes
         }


### PR DESCRIPTION
`-Xmx32G` does not actually lead to compressed references (ordinary
object pointers), contrary to what the function suggests.

Using openjdk64-11.0.2 the following behaviour can be observed:

* `-Xmx32G` - compressed oops not used
* `-Xmx31G` - compressed oops used
* `-Xmx32767M` - compressed oops not used
* `-Xmx32766M` - compressed oops used

So the actual threshold is ~ 32766 MB so just shy of 32GIB.

If `31G` is too much of a change compared to the previously returned
value of `32G`, the memory threshold might have to be expressed in `M`
instead of `G`.


Here's a self contained example (requires Java 11 to get https://openjdk.java.net/jeps/318) based on https://shipilev.net/jvm/anatomy-quarks/23-compressed-references/.

The example generates a `.java-version` file for https://www.jenv.be/, otherwise make sure to use Java 11.

Using `31G` you can see that compressed oops mode is enabled (as per the log output) and the example executes successfully.

```
% make 31
java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+heap+coops  -Xmx31g RandomAllocate 800000000
[0.010s][info][gc] Resizeable heap; starting at 256M, max: 31744M, step: 128M
[0.010s][info][gc] Using TLAB allocation; max: 4096K
[0.010s][info][gc] Elastic TLABs enabled; elasticity: 1.10x
[0.010s][info][gc] Elastic TLABs decay enabled; decay time: 1000ms
[0.010s][info][gc] Using Epsilon
[0.010s][info][gc,heap,coops] Heap address: 0x0000001000001000, size: 31744 MB, Compressed Oops mode: Non-zero disjoint base: 0x0000001000000000, Oop shift amount: 3
```

With `32G` you can see that compressed oops mode is not enabled and the example fails with an OOME:

```
% make 32
java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+heap+coops  -Xmx32g RandomAllocate 800000000
[0.007s][info][gc] Resizeable heap; starting at 256M, max: 32768M, step: 128M
[0.007s][info][gc] Using TLAB allocation; max: 4096K
[0.007s][info][gc] Elastic TLABs enabled; elasticity: 1.10x
[0.007s][info][gc] Elastic TLABs decay enabled; decay time: 1000ms
[0.007s][info][gc] Using Epsilon
[0.087s][info][gc] Heap: 32768M reserved, 6359M (19.41%) committed, 6104M (18.63%) used
[5.495s][info][gc] Heap: 32768M reserved, 7767M (23.70%) committed, 7742M (23.63%) used
...
[29.623s][info][gc] Heap: 32768M reserved, 32471M (99.10%) committed, 32320M (98.63%) used
Terminating due to java.lang.OutOfMemoryError: Java heap space
make: *** [Makefile:52: 32] Error 3
```


`Makefile`:

```
CMD := java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xlog:gc -Xlog:gc+heap+coops 
MAIN_ARGS := RandomAllocate 800000000

define testfile
import java.util.stream.IntStream;

public class RandomAllocate {
    static Object[] arr;

    public static void main(String... args) {
        int size = Integer.parseInt(args[0]);
        arr = new Object[size];
        IntStream.range(0, size).parallel().forEach(x -> arr[x] = new byte[(x % 20) + 1]);
        System.out.println("All done.");
    }
}
endef
export testfile

# For https://www.jenv.be/
#
# We need Java 11 to get EpsilonGC (https://openjdk.java.net/jeps/318) which
# will not attempt to do any garbage collection but shutdown the JVM instead.
.java-version:
	@echo "11.0" > .java-version

RandomAllocate.java: .java-version
	@echo "$$testfile" > RandomAllocate.java

RandomAllocate.class: RandomAllocate.java
	javac RandomAllocate.java


.PHONY:
clean:
	rm -f .java-version RandomAllocate.*

.PHONY:
ok: RandomAllocate.class
	$(CMD) -Xmx32766M $(MAIN_ARGS)

.PHONY:
threshold: RandomAllocate.class
	$(CMD) -Xmx32767M $(MAIN_ARGS)

.PHONY:
below-threshold: RandomAllocate.class
	$(CMD) -Xmx32766M $(MAIN_ARGS)

.PHONY:
32: RandomAllocate.class
	$(CMD) -Xmx$@g $(MAIN_ARGS)

.PHONY:
31: RandomAllocate.class
	$(CMD) -Xmx$@g $(MAIN_ARGS)

```
