### PR TITLE
DCNG-195: Remove SNAPSHOT from locks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     testCompile(project(":virtual-users"))
     testCompile(fileTree(mapOf("dir" to "lib", "include" to "*.jar")))
     testCompile("com.atlassian.performance.tools:jira-performance-tests:[3.3.0,4.0.0)")
+    testCompile("com.atlassian.performance.tools:aws-infrastructure:[2.10.0,3.0.0)")
     testCompile("com.atlassian.performance.tools:infrastructure:[4.12.0,5.0.0)")
     testCompile("com.atlassian.performance.tools:virtual-users:[3.6.2,4.0.0)")
     testCompile("com.atlassian.performance.tools:jira-software-actions:[1.1.0,2.0.0]")

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -11,7 +11,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.10.1-SNAPSHOT
+com.atlassian.performance.tools:aws-infrastructure:2.10.0
 com.atlassian.performance.tools:aws-resources:1.3.4
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:infrastructure:4.12.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -11,7 +11,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.10.1-SNAPSHOT
+com.atlassian.performance.tools:aws-infrastructure:2.10.0
 com.atlassian.performance.tools:aws-resources:1.3.4
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:infrastructure:4.12.2

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -11,7 +11,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.10.1-SNAPSHOT
+com.atlassian.performance.tools:aws-infrastructure:2.10.0
 com.atlassian.performance.tools:aws-resources:1.3.4
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:infrastructure:4.12.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -11,7 +11,7 @@ com.amazonaws:aws-java-sdk-s3:1.11.424
 com.amazonaws:aws-java-sdk-sts:1.11.424
 com.amazonaws:aws-java-sdk-support:1.11.424
 com.amazonaws:jmespath-java:1.11.424
-com.atlassian.performance.tools:aws-infrastructure:2.10.1-SNAPSHOT
+com.atlassian.performance.tools:aws-infrastructure:2.10.0
 com.atlassian.performance.tools:aws-resources:1.3.4
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:infrastructure:4.12.2


### PR DESCRIPTION
The dependency locks do not include `fileTree` dependencies.