### PR TITLE
QUICK-213: Clean up the XL7 dataset

### DIFF
--- a/src/test/kotlin/com/atlassian/performance/tools/hardware/HwrDatasetCatalogue.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/hardware/HwrDatasetCatalogue.kt
@@ -21,7 +21,8 @@ import java.time.Duration
 class HwrDatasetCatalogue {
 
     fun xl7Mysql() = StorageLocation(
-        uri = URI("s3://jpt-custom-mysql-xl/dataset-7m-jira7"),
+        uri = URI("s3://jpt-custom-datasets-storage-a008820-datasetbucket-1sjxdtrv5hdhj/")
+            .resolve("dataset-2ca38baf-5463-41cd-b2c8-a3c8e110b3c1"),
         region = Regions.EU_WEST_1
     ).let { location ->
         Dataset(


### PR DESCRIPTION
Apply the [cleanup](https://circleci.com/gh/dagguh/aws-infrastructure/34).
Avoid the QUICK-213 bug.
Reduce wasteful transfer for Jira home:
  * before: 98,1 GB
  * after: 65,7 GB