### PR TITLE
JPERF-968 Add ability to use a long term AWS credentials in the pipeline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,7 +63,9 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: eu-west-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 14400
       - name: Generate workflow URL
         run: echo "WORKFLOW_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV


### PR DESCRIPTION
Replace hardcoded region with environment variable.

The preferred way of authenticating in AWS is using IAM role, but 3rd party contributors might prefer using a key pair and with the previous config the key pair would not be picked up in the pipeline.